### PR TITLE
docs: banner - re-check Select all for M365 Copilot metrics in Viva Insights query

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 > **v13 is here** — this release adds compatibility with Viva Insights' newly consolidated Copilot Chat metrics (the old metrics are automatically rebuilt from the new merged ones, so every visual keeps working), and fixes a false "some Copilot Chat metrics are missing" warning plus a Power BI refresh error caused by a missing DisplayName column.
 >
 > **Download v13:** [CSV template](https://github.com/microsoft/superuserimpact/raw/main/Template%20-%20Super%20User%20Impact%20CSV%20-v13.pbit) &nbsp;&middot;&nbsp; [Direct Query template](https://github.com/microsoft/superuserimpact/raw/main/Template%20-%20Super%20User%20Impact%20Direct%20Query%20-v13.pbit)
+>
+> **Then update your Viva Insights query:** edit the query, open the **Microsoft 365 Copilot** metric selection, and re-check **Select all** so the newly consolidated Copilot Chat metrics are included in your export.
 
 <div align="center">
 


### PR DESCRIPTION
Adds a line to the v13 banner instructing users to edit their Viva Insights query and re-check **Select all** under the Microsoft 365 Copilot metric selection, so the newly consolidated Copilot Chat metrics are included in their export.